### PR TITLE
Reorder libraries for building demos.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ all:
 	$(LIBRARY_CLEAN)
 	$(LIBRARY_BUILD_ARGS)
 
-	g++ -o bin/demo examples/demo.cpp -lopencv_core -lopencv_highgui -lopencv_imgproc -I./src $(LINKLIB) -O3
-	g++ -o bin/segmentation examples/segmentation.cpp -lopencv_core -lopencv_highgui -lopencv_imgproc -I./src $(LINKLIB) -O3
+	g++ -o bin/demo examples/demo.cpp -I./src $(LINKLIB) -lopencv_core -lopencv_highgui -lopencv_imgproc -O3
+	g++ -o bin/segmentation examples/segmentation.cpp -I./src $(LINKLIB) -lopencv_core -lopencv_highgui -lopencv_imgproc -O3


### PR DESCRIPTION
List the CommodityTracking library first, then the OpenCV libraries.

On Ubuntu 14.04 with g++ 4.8.4 this is the only way I can get the demos to build
and link without errors.